### PR TITLE
Uses kseq to parse reference fasta

### DIFF
--- a/chromosomes.hpp
+++ b/chromosomes.hpp
@@ -6,7 +6,9 @@
 #include <fstream>
 #include <unordered_map>
 #include <iomanip>
+#include <zlib.h>
 
+#include "kseq.h"
 #include "config.hpp"
 #include "lprint.hpp"
 


### PR DESCRIPTION
Was there any reason behind not using kseq to parse reference fasta? This pr changes the function to read and load chromosomes. Tested on chr21 data I have locally - output is the same.

*Pro:* we don't have to manage different headers (22/chr22)

*Cons:* there are 3 warnings (when compiling fastq.hpp)